### PR TITLE
remove including functions

### DIFF
--- a/tests/test-vlo.php
+++ b/tests/test-vlo.php
@@ -6,11 +6,6 @@
  */
 
 /**
- * Require wp-view-login-only function.
- */
-require_once( './wp-view-login-only.php' );
-
-/**
  * Test case.
  */
 class VloTest extends WP_UnitTestCase {


### PR DESCRIPTION
`wp scaffold plugin-tests` で生成されたテストコードには、そのテスト対象のプラグインをWordPressで有効化するためのコードが自動的に作られています。
（つまりこのプラグインは `phpunit`と叩いた瞬間に実際にWordPressにインストールされ有効化された状態でテストが行われます！すごいでしょ！）

https://github.com/chiilog/wp-view-login-only/blob/master/tests/bootstrap.php#L20

もしプラグインが有効化されているなら、`./wp-view-login-only.php` が自動的に `require` されるはずなので、テストに `require` を書く必要はありませんし、むしろ書くべきでもありません。テストコードで `require` しないといけないシチュエーションになったら、それはむしろプラグインのどこかにバグが潜んでると考えましょう。